### PR TITLE
PKG-8899: webob 1.8.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python
     - pip
     - wheel
+    - setuptools
   run:
     - python
     - legacy-cgi >=2.6 # [py>=313]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - python
     - pip
     - wheel
-    - setuptools >=41
   run:
     - python
     - legacy-cgi >=2.6 # [py>=313]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,36 +1,44 @@
-{% set name = "WebOb" %}
-{% set version = "1.8.7" %}
-{% set sha256 = "b64ef5141be559cfade448f044fa45c2260351edcb6a8ef6b7e00c7dcef0c323" %}
+{% set name = "webob" %}
+{% set version = "1.8.9" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: ad6078e2edb6766d1334ec3dee072ac6a7f95b1e32ce10def8ff7f0f02d56589
 
 build:
-  noarch: python
+  skip: true # [py<39]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - pip
     - python
-    - setuptools
-
+    - pip
+    - wheel
+    - setuptools >=41
   run:
     - python
+    - legacy-cgi >=2.6 # [py>=313]
 
 test:
   imports:
     - webob
+  source_files:
+    - tests
+  requires:
+    - pip
+    - pytest >=3.1.0
+  commands:
+    - pip check
+    - pytest -v tests
 
 about:
-  home: http://webob.org/
+  home: https://webob.org/
+  license_file: docs/license.txt
   license: MIT
   license_family: MIT
   summary: 'WSGI request and response object'
@@ -41,9 +49,8 @@ about:
     many conveniences for parsing HTTP request and forming HTTP responses. Both
     objects are read/write: as a result, WebOb is also a nice way to create HTTP
     requests and parse HTTP responses.
-  doc_url: http://webob.readthedocs.org/
+  doc_url: https://docs.pylonsproject.org/projects/webob/
   dev_url: https://github.com/Pylons/webob/
-  doc_source_url: https://github.com/Pylons/webob/blob/master/docs/index.txt
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: ad6078e2edb6766d1334ec3dee072ac6a7f95b1e32ce10def8ff7f0f02d56589
 
 build:
@@ -37,7 +37,7 @@ test:
     - pytest -v tests
 
 about:
-  home: https://webob.org/
+  home: https://webob.org
   license_file: docs/license.txt
   license: MIT
   license_family: MIT
@@ -49,8 +49,8 @@ about:
     many conveniences for parsing HTTP request and forming HTTP responses. Both
     objects are read/write: as a result, WebOb is also a nice way to create HTTP
     requests and parse HTTP responses.
-  doc_url: https://docs.pylonsproject.org/projects/webob/
-  dev_url: https://github.com/Pylons/webob/
+  doc_url: https://docs.pylonsproject.org/projects/webob
+  dev_url: https://github.com/Pylons/webob
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
webob 1.8.9

**Destination channel:** Defaults

### Links

- [PKG-8899](https://anaconda.atlassian.net/browse/PKG-8899)
- dev_url: https://github.com/Pylons/webob/tree/1.8.9
- conda-forge: https://github.com/conda-forge/webob-feedstock
- pypi: https://pypi.org/project/WebOb/

### Explanation of changes:

- Update to version 1.8.9
- Add testing
- Add license file


[PKG-8899]: https://anaconda.atlassian.net/browse/PKG-8899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ