### PR TITLE
Update webob to 1.8.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,14 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 1c963a11f307bc3f624fbab9dde737701eae255f32981b7a5486a88db1767c2b
+  patches:
+    # Python 3.14 increased io.DEFAULT_BUFFER_SIZE; upstream fix pending release
+    # https://github.com/Pylons/webob/commit/447975fe
+    - patches/0001-fix-py314-interrupted-request-test.patch
 
 build:
   skip: true # [py<39]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,7 @@ source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 1c963a11f307bc3f624fbab9dde737701eae255f32981b7a5486a88db1767c2b
   patches:
-    # Python 3.14 increased io.DEFAULT_BUFFER_SIZE; upstream fix pending release
-    # https://github.com/Pylons/webob/commit/447975fe
+    # Backport https://github.com/Pylons/webob/commit/447975fe (py3.14 DEFAULT_BUFFER_SIZE)
     - patches/0001-fix-py314-interrupted-request-test.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: true # [py<39]
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "webob" %}
-{% set version = "1.8.9" %}
+{% set version = "1.8.10" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ad6078e2edb6766d1334ec3dee072ac6a7f95b1e32ce10def8ff7f0f02d56589
+  sha256: 1c963a11f307bc3f624fbab9dde737701eae255f32981b7a5486a88db1767c2b
 
 build:
   skip: true # [py<39]

--- a/recipe/patches/0001-fix-py314-interrupted-request-test.patch
+++ b/recipe/patches/0001-fix-py314-interrupted-request-test.patch
@@ -1,0 +1,47 @@
+--- a/tests/test_in_wsgiref.py
++++ b/tests/test_in_wsgiref.py
+@@ -2,6 +2,7 @@
+ import logging
+ import socket
+ import cgi
++from io import DEFAULT_BUFFER_SIZE
+ 
+ import pytest
+ 
+@@ -15,6 +16,8 @@
+ 
+ log = logging.getLogger(__name__)
+ 
++TARGET_CL = DEFAULT_BUFFER_SIZE * 2
++
+ @pytest.mark.usefixtures("serve")
+ def test_request_reading(serve):
+     """
+@@ -61,7 +64,7 @@
+ 
+ 
+ def _test_app_req_interrupt(env, sr):
+-    target_cl = 100000
++    target_cl = TARGET_CL
+     try:
+         req = Request(env)
+         cl = req.content_length
+@@ -89,7 +92,7 @@
+ def _req_int_readline(req):
+     try:
+         assert req.body_file.readline() == b'a=b\n'
+-    except IOError:
++    except OSError:
+         # too early to detect disconnect
+         raise AssertionError("False disconnect alert")
+     req.body_file.readline()
+@@ -121,7 +124,7 @@
+ _interrupted_req = (
+     "POST %s HTTP/1.0\r\n"
+     "content-type: application/x-www-form-urlencoded\r\n"
+-    "content-length: 100000\r\n"
++    f"content-length: {TARGET_CL}\r\n"
+     "\r\n"
+ )
+-_interrupted_req += 'a=b\nz=' + 'x' * 10000
++_interrupted_req += 'a=b\nz=' + 'x' * DEFAULT_BUFFER_SIZE

--- a/recipe/patches/0001-fix-py314-interrupted-request-test.patch
+++ b/recipe/patches/0001-fix-py314-interrupted-request-test.patch
@@ -1,3 +1,17 @@
+From 447975febec7fc6bb088698bdeaa151bf5028a86 Mon Sep 17 00:00:00 2001
+From: Delta Regeer <bertjw@regeer.org>
+Date: Sun, 15 Mar 2026 13:08:24 -0600
+Subject: [PATCH] Python 3.14 updated the DEFAULT_BUFFER_SIZE to be larger
+
+This broke the test that assumed it would be 8192. Fix things so that
+the tests now correctly test things again.
+
+Backported from https://github.com/Pylons/webob/commit/447975fe for 1.8.10.
+---
+ tests/test_in_wsgiref.py | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/tests/test_in_wsgiref.py b/tests/test_in_wsgiref.py
 --- a/tests/test_in_wsgiref.py
 +++ b/tests/test_in_wsgiref.py
 @@ -2,6 +2,7 @@
@@ -8,16 +22,17 @@
  
  import pytest
  
-@@ -15,6 +16,8 @@
+@@ -15,6 +16,9 @@
  
  log = logging.getLogger(__name__)
  
 +TARGET_CL = DEFAULT_BUFFER_SIZE * 2
 +
++
  @pytest.mark.usefixtures("serve")
  def test_request_reading(serve):
      """
-@@ -61,7 +64,7 @@
+@@ -61,7 +65,7 @@
  
  
  def _test_app_req_interrupt(env, sr):
@@ -26,16 +41,16 @@
      try:
          req = Request(env)
          cl = req.content_length
-@@ -89,7 +92,7 @@
+@@ -89,7 +93,7 @@
  def _req_int_readline(req):
      try:
          assert req.body_file.readline() == b'a=b\n'
 -    except IOError:
-+    except OSError:
++    except OSError as exc:
          # too early to detect disconnect
          raise AssertionError("False disconnect alert")
      req.body_file.readline()
-@@ -121,7 +124,7 @@
+@@ -121,7 +125,7 @@
  _interrupted_req = (
      "POST %s HTTP/1.0\r\n"
      "content-type: application/x-www-form-urlencoded\r\n"


### PR DESCRIPTION
## webob 1.8.10
**Destination channel:** defaults


### Links
- [PKG-15132](https://anaconda.atlassian.net/browse/PKG-15132)
- [PyPI](https://pypi.org/project/WebOb/1.8.10/)
- [GitHub](https://github.com/Pylons/webob/tree/v1.8.3)
### Explanation of changes:
- Updated webob from 1.8.9 to 1.8.10
- Security patch for incomplete CVE-2024-42353 open-redirect fix ([GHSA-fh3h-vg37-cc95](https://github.com/Pylons/webob/security/advisories/GHSA-fh3h-vg37-cc95))
- No dependency changes (`legacy-cgi >=2.6` for py3.13+ unchanged)


[PKG-15132]: https://anaconda.atlassian.net/browse/PKG-15132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ